### PR TITLE
Contextually set config values, with fallbacks

### DIFF
--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -24,21 +24,26 @@ module SequelPro
 				ssh_info = machine.ssh_info
 				raise Vagrant::Errors::SSHNotReady if ssh_info.nil?
 
-				# If we don't have custom SSH use the defaults
+				ssh_config = {
+					# Custom IP overrides default host
+					"host" => config["ip"] || ssh_info[:host],
+					"port" => ssh_info[:port],
+					"user" => ssh_info[:username],
+					"private_key_path" => ssh_info[:private_key_path],
+				}
+
 				if ! config["ssh"]
+					# If we don't have custom SSH use the defaults
 					data = {
-						"ssh" => {
-							# Custom IP overrides default host
-							"host" => config["ip"] || ssh_info[:host],
-							"port" => ssh_info[:port],
-							"user" => ssh_info[:username],
-							"private_key_path" => ssh_info[:private_key_path],
-						}
+						"ssh" => ssh_config
 					}
-					data = config.merge(data)
-				elsif
-					data = config
+				else
+					# Fall back to defaults for any unspecified custom SSH properties
+					data = {
+						"ssh" => ssh_config.merge(config["ssh"]),
+					}
 				end
+				data = config.merge(data)
 
 				# Output template
 				content = template.result OpenStruct.new(data).instance_eval { binding }

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -28,7 +28,8 @@ module SequelPro
 				if ! config["ssh"]
 					data = {
 						"ssh" => {
-							"host" => ssh_info[:host],
+							# Custom IP overrides default host
+							"host" => config["ip"] || ssh_info[:host],
 							"port" => ssh_info[:port],
 							"user" => ssh_info[:username],
 							"private_key_path" => ssh_info[:private_key_path],


### PR DESCRIPTION
Because of how we set our `ssh` configuration, if any property is specified then all properties must be specified. This is counterproductive because it forces the full private key path to be hard coded into your configuration in order to set the host or the user, requiring a change whenever your box updates.

This PR changes how the configuration is set, to

- Use the `ip` from the config file as the default for the ssh.host property, if `ip` is present; and,
- Fall back to the defaults for any child properties of `ssh` which are not specified in the config