### PR TITLE
Clean up and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ extensions:
   - chassis/sequelpro
 ```
 
-(For manual installation, clone this repository into your Chassis `extensions` directory.)
+(For manual installation in an individual Chassis box, clone this repository into that Chassis box's `extensions` directory.)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,37 +11,50 @@ We recommend [installing this extension globally](http://docs.chassis.io/en/late
 git clone https://github.com/Chassis/SequelPro ~/.chassis/extensions/sequelpro
 ```
 
-Alternatively to install this extension into a single Chassis box, add `Chassis/SequelPro` to your `extensions` list in your `config.local.yaml`:
+Alternatively to install this extension into a single Chassis box, add `chassis/sequelpro` to your `extensions` list in your `config.local.yaml`:
 
 ```yaml
 extensions:
-- Chassis/SequelPro
+- chassis/sequelpro
 ```
 
 (For manual installation, clone this repository into your Chassis `extensions` directory.)
 
 
-## Using
+## Usage
 
-Simply run `vagrant sequel`.
+Once the virtual machine is running, run `vagrant sequel` within the Chassis folder to open the VM's databases in Sequel Pro.
 
 ## Configuration
 
-The SequelPro extension allows for custom configuration options which can be added in one of your [configuation files](https://docs.chassis.io/en/latest/config/). Here's an example configuration:
+The SequelPro extension allows for custom configuration options which can be added in one of your [configuration files](https://docs.chassis.io/en/latest/config/). Here's an example configuration:
 
-```
+```yaml
 # MySQL database details.
 database:
-    name: your_database
-    user: your_username
-    password: your_password
-	prefix: bq_
+  name: your_database
+  user: your_username
+  password: your_password
+  prefix: bq_
 ssh:
-    host: 10.1.2.3
-    user: custom_user
-    port: 33060
-    private_key_path:
-        - /Users/username/.vagrant.d/boxes/chassis-VAGRANTSLASH-chassis/3.0.3/virtualbox/vagrant_private_key
+  host: 10.1.2.3
+  user: custom_user
+  port: 33060
+  private_key_path:
+    - /Users/username/.vagrant.d/boxes/chassis-VAGRANTSLASH-chassis/3.0.3/virtualbox/vagrant_private_key
+```
+
+Any property you omit within the `ssh:` section will fall back to a default value, so you may specify for example only "port" or "user" without filling out every value.
+
+If your configuration file specifies a custom `ip:`, that value will be used as the default for the `ssh.host` property.
+
+```yaml
+# Example simplified configuration:
+# Use the default database values, a custom IP, and port 22
+ip: 10.86.73.15
+
+ssh:
+  port: 22
 ```
 
 ## Connection Errors
@@ -55,16 +68,18 @@ If you get this error on macOS Sierra, it's possible that you have too many SSH 
 
 The simple solution is to add this to your `~/.ssh/config` file:
 
-	# Disable checks on Vagrant machines
-	Host 127.0.0.1
-		# Skip adding to agent
-		AddKeysToAgent no
+```
+# Disable checks on Vagrant machines
+Host 127.0.0.1
+	# Skip adding to agent
+	AddKeysToAgent no
 
-		# Only use key specified on CLI
-		IdentitiesOnly yes
+	# Only use key specified on CLI
+	IdentitiesOnly yes
 
-		# Skip known hosts
-		UserKnownHostsFile /dev/null
-		StrictHostKeyChecking no
+	# Skip known hosts
+	UserKnownHostsFile /dev/null
+	StrictHostKeyChecking no
+```
 
-This disables using system-level keys (both from the agent, and your regular SSH keys), and disables host checks (which are not necessary for localhost). This does not affect `vagrant ssh`, which already uses these options.
+This disables using system-level keys (both from the agent, and your regular SSH keys), and disables host checks (which are not necessary for `localhost`). This does not affect `vagrant ssh`, which already uses these options.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively to install this extension into a single Chassis box, add `chassis/
 
 ```yaml
 extensions:
-- chassis/sequelpro
+  - chassis/sequelpro
 ```
 
 (For manual installation, clone this repository into your Chassis `extensions` directory.)


### PR DESCRIPTION
- Fixes #10 by adding an IP hosts default note
- Explains that all values now fall back to defaults
- Fixes some typos and cleans up code block formatting in a few places
- Lowercases `chassis/sequelpro` in extensions list to match case of the git checkout command's target directory, and to make extension cloning behavior a tad more consistent on case-sensitive file systems like ext4
- Couple typos and minor points of clarity

